### PR TITLE
Corrects bug in type discovery.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "index.js",
   "module": "index.js",
+  "types": "index.d.ts",
   "files": [
     "index.js",
     "index.d.ts",


### PR DESCRIPTION
For reasons I don't understand, TypeScript is finding `index.ts` instead of `index.d.ts` when it goes looking for types for `index.js`. This is despite the docs saying that it will find `index.d.ts`. https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

None the less, this can be resolved by just being explicit, as done in this PR.

I asked about this in an ongoing thread on the issue, hopefully I'll get some clarity on why the defaults aren't working here:
https://github.com/microsoft/TypeScript/issues/40426#issuecomment-1383186169