### PR TITLE
Increases strictness of type checker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+node_modules/
 build/
 test/web3js-transactions.json
 /*.js
 /*.d.ts
 /*.d.ts.map
+package-lock.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/index.ts
+++ b/index.ts
@@ -369,6 +369,7 @@ export class Transaction {
   get chain(): Chain | undefined {
     for (let k in CHAIN_TYPES)
       if (CHAIN_TYPES[k as Chain] === Number(this.raw.chainId!)) return k as Chain;
+    return undefined;
   }
 
   get sender(): string {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "build": "tsc && rollup -c rollup.config.js",
     "bench": "node test/benchmark.js",
     "lint": "prettier --print-width 100 --single-quote --check index.ts",
+    "format": "prettier --print-width 100 --single-quote --write index.ts",
     "test": "node test/test.js"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "removeComments": true,
     "preserveConstEnums": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
   },
   "include": ["index.ts", "formatters.ts", "tx-validator.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
There are a few minor changes here.  I can split them up into multiple PRs if desired, but since they are all individually so tiny I figured it would be reasonable to throw them all into one.

Adds a check that ensures every function with a return statement returns from all code paths. There was one place where this wasn't happening, which was fixed.

Added `node_modules` and `package-lock.json` to `.gitignore`. I'm not sure why `node_modules` wasn't present.
I also added `package-lock.json` because I know the maintainers don't commit it, though I personally think it should be committed so builds are reliably reproducible.

Added vscode setting to use locally installed TS when using this project, rather than globally installed.