### PR TITLE
Updates to @ethereumjs/rlp

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@
 import { keccak_256 } from '@noble/hashes/sha3';
 import { bytesToHex, hexToBytes as _hexToBytes } from '@noble/hashes/utils';
 import * as secp256k1 from '@noble/secp256k1';
-import RLP from 'rlp';
+import * as RLP from '@ethereumjs/rlp';
 
 export const CHAIN_TYPES = { mainnet: 1, ropsten: 3, rinkeby: 4, goerli: 5, kovan: 42 };
 export const TRANSACTION_TYPES = { legacy: 0, eip2930: 1, eip1559: 2 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@noble/hashes": "~1.1.2",
     "@noble/secp256k1": "~1.6.3",
-    "rlp": "3.0.0"
+    "@ethereumjs/rlp": "4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "22.0.0",

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,8 +1,8 @@
-const { run, mark, logMem } = require('micro-bmark');
-const signer = require('..');
+import { run, mark, logMem } from 'micro-bmark';
+import { Transaction } from '../index.js'
 
 run(async () => {
-  const getTx = () => new signer.Transaction({
+  const getTx = () => new Transaction({
     to: '0xdf90dea0e0bf5ca6d2a7f0cb86874ba6714f463e',
     maxFeePerGas: 100n * 10n ** 9n, // 100 gwei in wei
     value: 10n ** 18n, // 1 eth in wei


### PR DESCRIPTION
This should make the library work natively in a browser.

Also makes benchmarks run.
Since `package.json` is `type: module`, the benchmark will run as a module which means no `require`.
I don't know how this ever worked, but this change makes `npm run bench` work.