### PR TITLE
fix: correct export path for ./advanced/abi.js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ".": "./index.js",
     "./net.js": "./net.js",
     "./utils.js": "./utils.js",
-    "./advanced/abi.js": "./advanced/ai.js",
+    "./advanced/abi.js": "./advanced/abi.js",
     "./advanced/kzg.js": "./advanced/kzg.js",
     "./advanced/ssz.js": "./advanced/ssz.js",
     "./advanced/verkle.js": "./advanced/verkle.js"


### PR DESCRIPTION
Corrects package.json export path for ./advanced/abi.js to fix import errors.