### PR TITLE
fix: remove tx value range check in non-strict mode

### DIFF
--- a/src/core/tx-internal.ts
+++ b/src/core/tx-internal.ts
@@ -483,9 +483,9 @@ const validators: Record<string, (num: any, { strict, type, data }: ValidationOp
     if (strict && address === '0x' && !data.data)
       throw new Error('Empty address (0x) without contract deployment code');
   },
-  value(num: bigint) {
+  value(num: bigint, { strict }: ValidationOpts) {
     abig(num);
-    minmax(num, _0n, amounts.maxAmount, '>= 0 and < 100M eth');
+    if (strict) minmax(num, _0n, amounts.maxAmount, '>= 0 and < 1M eth');
   },
   data(val: string, { strict, data }: ValidationOpts) {
     if (typeof val !== 'string') throw new Error('data must be string');


### PR DESCRIPTION
At the moment, tx validation enforces an arbitrary maximum value of 1M eth for the tx value, even in non-strict validation mode.

This PR limits that check to the strict mode only. It also aligns the maximum value in the error message, currently hardcoded as `100M`, with the actual value of `1M`, as defined [here](https://github.com/paulmillr/micro-eth-signer/blob/588f7db7e62b125f0e7023850b8016600107f875/src/utils.ts#L52).