### PR TITLE
fix: handle tuple array type in MapType definition

### DIFF
--- a/src/advanced/abi-mapper.ts
+++ b/src/advanced/abi-mapper.ts
@@ -54,6 +54,7 @@ export type MapTuple<T> =
 // prettier-ignore
 export type MapType<T extends BaseComponent> =
   T extends Tuple<Array<Component<string>>> ? MapTuple<T['components']> :
+  T extends { readonly type: 'tuple[]'; readonly components: infer C extends Array<Component<string>> } ? MapTuple<C>[] :
   T extends Component<infer Type> ? GetType<Type> :
   unknown; // default
 export type UnmapType<T> = T extends MapType<infer U> ? U : never;


### PR DESCRIPTION
Simply fixes `tuple[]` discovery

ABI

```json
{
    "inputs": [
        {
            "name": "calls",
            "type": "tuple[]",
            "internalType": "struct ProxyCall[]",
            "components": [
                {
                    "internalType": "address",
                    "name": "recipient",
                    "type": "address"
                },
                {
                    "internalType": "uint256",
                    "name": "amount",
                    "type": "uint256"
                }
            ],
        }
    ],
    "name": "execForward",
    "outputs": [],
    "stateMutability": "payable",
    "type": "function"
}
```

Current behavior

```ts
ContractMethod.encodeInput: (v: unknown[]) => Uint8Array<ArrayBufferLike>
```


Expected

```ts
ContractMethod.encodeInput: (v: {
    recipient: string;
    amount: bigint;
}[]) => Uint8Array<ArrayBufferLike>
```