### PR TITLE
fix: reject non-canonical leading-zero integer tx fields

### DIFF
--- a/src/core/tx-internal.ts
+++ b/src/core/tx-internal.ts
@@ -152,8 +152,25 @@ export const legacySig = /* @__PURE__ */ (() => ({
 
 type BytesBigintCoder = P.Coder<Bytes, bigint>;
 type BytesNumberCoder = P.Coder<Bytes, number>;
-const U64BE: BytesBigintCoder = P.coders.reverse(P.bigint(8, false, false, false));
-const U256BE: BytesBigintCoder = P.coders.reverse(P.bigint(32, false, false, false));
+// Ethereum scalars are RLP byte strings without leading zeros: a zero value is the empty
+// string, any other value's first byte is non-zero. ethereum-tests reject leading-zero
+// encodings (e.g. ttGasPrice/TransactionWithLeadingZerosGasPrice, ttEIP1559/maxFeePerGas00prefix),
+// so we reject them here too; otherwise distinct byte encodings decode to the same tx and the
+// tx hash silently changes on re-serialization.
+const noLeadingZeroScalar = (coder: BytesBigintCoder): BytesBigintCoder => ({
+  encode(from: Bytes) {
+    if (isBytes(from) && from.length > 0 && from[0] === 0)
+      throw new Error('non-canonical integer: leading zero bytes');
+    return coder.encode(from);
+  },
+  decode: (to) => coder.decode(to),
+});
+const U64BE: BytesBigintCoder = noLeadingZeroScalar(
+  P.coders.reverse(P.bigint(8, false, false, false))
+);
+const U256BE: BytesBigintCoder = noLeadingZeroScalar(
+  P.coders.reverse(P.bigint(32, false, false, false))
+);
 
 // Small coder utils
 // TODO: seems generic enought for packed? or RLP (seems useful for structured encoding/decoding of RLP stuff)

--- a/test/tx.test.ts
+++ b/test/tx.test.ts
@@ -109,13 +109,10 @@ const SKIPPED_ERRORS = {
     'TransactionWithHighGasLimit63Plus1',
     'TransactionWithHighGasLimit63Minus1',
     'TransactionWithHighNonce64Minus2',
-    'TransactionWithLeadingZerosGasPrice',
     'TransactionWithHighNonce32',
-    'TransactionWithZerosBigInt',
     'RightVRSTestF0000000c',
     'RightVRSTestVPrefixedBy0',
     'RightVRSTestF0000000b',
-    'TransactionWithSvaluePrefixed00BigInt',
     'TransactionWithRvalueTooHigh',
     'TransactionWithSvalue0',
     'TransactionWithSvalueLargerThan_c_secp256k1n_x05',
@@ -157,9 +154,6 @@ const SKIPPED_ERRORS = {
     'V_wrongvalue_ff',
     'V_wrongvalue_124',
     'TransactionWithHighValue',
-    'TransactionWithLeadingZerosValue',
-    'TransactionWithLeadingZerosNonce',
-    'TransactionWithRvaluePrefixed00BigInt',
   ],
 };
 


### PR DESCRIPTION
## Problem

Ethereum scalar fields (nonce, gasPrice, value, gasLimit, chainId, the EIP-1559/4844 fee fields, `r` and `s`) are RLP byte strings with no leading zeros: a zero value is the empty string, and any other value's first byte is non-zero.

The transaction decoder (`U64BE` / `U256BE` in `src/core/tx-internal.ts`) folds the raw field bytes into a bigint and silently ignores leading zeros. So a leading-zero-padded field decodes to the same logical transaction but re-serializes to different bytes, changing the transaction hash. A signer, indexer or mempool built on this library then computes a hash that no canonical client agrees with, and accepts transactions that mainnet rejects.

## Evidence

The official Ethereum `TransactionTests` (already vendored under `test/vectors`) declare a mandatory exception for these encodings on every fork:

- `ttGasPrice/TransactionWithLeadingZerosGasPrice` -> `LeadingZerosGasPrice`
- `ttEIP1559/maxFeePerGas00prefix` -> `1559LeadingZerosBaseFee`
- `ttNonce/TransactionWithLeadingZerosNonce` -> `LeadingZerosNonce`
- `ttRSValue/TransactionWithRvaluePrefixed00BigInt` -> `LeadingZerosR`

The suite was skipping exactly these vectors through `SKIPPED_ERRORS.ethereum_tests`.

## Fix

Wrap the variable-width scalar coders so they reject a leading zero byte, and un-skip the six vectors. `yParity` (fixed width) and byte-string fields (`to`, `data`, access-list keys, blob hashes) are left untouched, since those may legitimately start with `0x00`. The empty-string zero (`0x80`) still decodes to `0n`.

## Tests

- Red baseline: with the vectors un-skipped and the source reverted, the suite fails with `Missing expected exception: throws(ttGasPrice/TransactionWithLeadingZerosGasPrice)`.
- With the fix: full suite green (429 tests), all official leading-zero vectors rejected, canonical transactions round-trip byte-identical, sender recovery unchanged.